### PR TITLE
Set the "pipefail" option for shell pipelines in the generated Makefile

### DIFF
--- a/fermi2.pl
+++ b/fermi2.pl
@@ -107,6 +107,7 @@ Options: -p STR    output prefix [$opts{p}]
 	push(@lines, qq/K_UNITIG=$opts{k}/, qq/K_CLEAN=$opts{o}/, qq/K_TRIM=$opts{T}/, qq/K_MERGE=$opts{m}/);
 	push(@lines, qq/N_THREADS=$opts{t}/, "");
 	push(@lines, (-f $ARGV[0])? qq/INPUT=cat $ARGV[0]/ : qq/INPUT=$ARGV[0]/, "");
+	push(@lines, "SHELL:=/bin/bash", qq/export SHELLOPTS:=errexit:pipefail/, "");
 
 	push(@lines, qq/all:\$(PREFIX).mag.gz/, "");
 
@@ -114,11 +115,11 @@ Options: -p STR    output prefix [$opts{p}]
 	if (defined $opts{E}) {
 		push(@lines, (-f $ARGV[0])? qq/\tln -s $ARGV[0] \$@/ : qq/\t$(INPUT) | gzip -1 > $@/, "");
 	} elsif (defined $opts{2}) {
-		push(@lines, qq/\tbash -c '\$(EXE_BFC) -s \$(GENOME_SIZE)  -k \$(K_EC1) -t \$(N_THREADS) <(\$(INPUT)) <(\$(INPUT)) 2> \$@.log | gzip -1 > \$(PREFIX).ec1.fq.gz'; \\/);
-		push(@lines, qq/\tbash -c '\$(EXE_BFC) -s \$(GENOME_SIZE) -Rk \$(K_EC2) -t \$(N_THREADS) <(\$(INPUT)) \$(PREFIX).ec1.fq.gz 2>> \$@.log | gzip -1 > \$\@'; \\/);
+		push(@lines, qq/\tbash -e -o pipefail -c '\$(EXE_BFC) -s \$(GENOME_SIZE)  -k \$(K_EC1) -t \$(N_THREADS) <(\$(INPUT)) <(\$(INPUT)) 2> \$@.log | gzip -1 > \$(PREFIX).ec1.fq.gz'; \\/);
+		push(@lines, qq/\tbash -e -o pipefail -c '\$(EXE_BFC) -s \$(GENOME_SIZE) -Rk \$(K_EC2) -t \$(N_THREADS) <(\$(INPUT)) \$(PREFIX).ec1.fq.gz 2>> \$@.log | gzip -1 > \$\@'; \\/);
 		push(@lines, qq/\trm -f \$(PREFIX).ec1.fq.gz/, "");
 	} else {
-		push(@lines, qq/\tbash -c '\$(EXE_BFC) -s \$(GENOME_SIZE) -t \$(N_THREADS) <(\$(INPUT)) <(\$(INPUT)) 2> \$@.log | gzip -1 > \$\@'/, "");
+		push(@lines, qq/\tbash -e -o pipefail -c '\$(EXE_BFC) -s \$(GENOME_SIZE) -t \$(N_THREADS) <(\$(INPUT)) <(\$(INPUT)) 2> \$@.log | gzip -1 > \$\@'/, "");
 	}
 
 	push(@lines, qq/\$(PREFIX).flt.fq.gz:\$(PREFIX).ec.fq.gz/);


### PR DESCRIPTION
The generated Makefile has some shell pipelines like `foo | gzip > result`. By default in bash, the exit code of the pipeline is that of gzip, which is usually successful even if foo crashes. The pipefail option to bash ensures that any nonzero exit code of foo gets surfaced.

Previously I found that if the upstream steps crash (e.g. due to out of memory), the downstream steps continue with an empty output, and make has a 0 exit code. Maybe there's even a chance it would continue with a partial output.
